### PR TITLE
Support Codex CLI as an agent runtime

### DIFF
--- a/src/acceptance.rs
+++ b/src/acceptance.rs
@@ -8,8 +8,8 @@
 //! - **Primary**: a strict JSON verdict object of the form
 //!   `{"acceptance":"pass|fail|continue|gated","findings":[...]}` emitted as
 //!   the final machine-readable verdict payload. JSON verdicts may appear
-//!   directly as a line on stdout, or wrapped inside an
-//!   `opencode run --format json` event (assistant / result / stream_event
+//!   directly as a line on stdout, or wrapped inside a supported agent JSONL
+//!   event (assistant / result / stream_event / Codex item.completed
 //!   text payloads). In either case the runtime unwraps the payload and
 //!   evaluates the JSON verdict.
 //! - **Fallback**: legacy plain-text standalone verdict markers of the form
@@ -91,8 +91,8 @@ pub(crate) fn parse_json_verdict(text: &str) -> Option<(&'static str, Vec<String
 /// Preference order:
 ///
 /// 1. Strict JSON verdict object on the line itself (primary contract).
-/// 2. Strict JSON verdict object inside an unwrapped
-///    `opencode run --format json` event text payload.
+/// 2. Strict JSON verdict object inside an unwrapped supported agent JSONL
+///    event text payload.
 /// 3. Legacy plain-text standalone canonical marker on the line itself, or
 ///    inside the unwrapped event payload (backward-compatible fallback).
 ///
@@ -140,8 +140,8 @@ pub(crate) fn canonical_verdict_kind(line: &str) -> Option<&'static str> {
 ///
 /// - Primary: a strict JSON verdict object
 ///   `{"acceptance":"pass|fail|continue|gated","findings":[...]}` emitted
-///   either directly as a line, or wrapped inside an `opencode run
-///   --format json` event payload (assistant / stream_event / result text).
+///   either directly as a line, or wrapped inside a supported agent JSONL event
+///   payload (assistant / stream_event / result / Codex item.completed text).
 ///   The first JSON verdict encountered wins, regardless of any earlier text
 ///   marker.
 /// - Fallback: a standalone legacy line equal to one of `ACCEPTANCE: PASS`,
@@ -172,8 +172,7 @@ pub fn parse_acceptance_output(output: &str) -> AcceptanceResult {
         }
 
         // Collect scan candidates: the raw line, plus unwrapped event text when
-        // the line is a stream-json event wrapper (from `opencode run
-        // --format json` and similar event streams).
+        // the line is a supported JSONL event wrapper from an agent runtime.
         let mut candidates: Vec<String> = vec![trimmed.to_string()];
         if let Some(text) = crate::stream_json_textifier::extract_text_from_stream_json(trimmed) {
             for inner in text.lines() {
@@ -938,8 +937,8 @@ ACCEPTANCE: PASSAll acceptance criteria verified:
     }
 
     #[test]
-    fn test_parse_acceptance_output_json_inside_opencode_format_json_assistant_event() {
-        // `opencode run --format json` wraps final text in an assistant event.
+    fn test_parse_acceptance_output_json_inside_agent_assistant_event() {
+        // Some agent JSONL formats wrap final text in an assistant event.
         // The parser must unwrap the text payload and still find the JSON verdict.
         let event = r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"{\"acceptance\":\"pass\"}"}]}}"#;
         let output = format!("{}\n", event);
@@ -947,10 +946,9 @@ ACCEPTANCE: PASSAll acceptance criteria verified:
     }
 
     #[test]
-    fn test_parse_acceptance_output_json_inside_opencode_format_json_result_event() {
-        // Final result event from `opencode run --format json` / Claude Code
-        // stream-json carries the assistant's final text in `result`. Parser
-        // must unwrap and accept the JSON verdict.
+    fn test_parse_acceptance_output_json_inside_agent_result_event() {
+        // Some agent JSONL formats carry the assistant's final text in `result`.
+        // Parser must unwrap and accept the JSON verdict.
         let event = r#"{"type":"result","subtype":"success","result":"{\"acceptance\":\"fail\",\"findings\":[\"a\"]}","is_error":false}"#;
         let output = format!("{}\n", event);
         match parse_acceptance_output(&output) {
@@ -959,6 +957,13 @@ ACCEPTANCE: PASSAll acceptance criteria verified:
             }
             other => panic!("expected Fail, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_parse_acceptance_output_json_inside_codex_item_completed_event() {
+        let event = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"{\"acceptance\":\"pass\"}"}}"#;
+        let output = format!("{}\n", event);
+        assert_eq!(parse_acceptance_output(&output), AcceptanceResult::Pass);
     }
 
     #[test]

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -4,6 +4,14 @@
 /// Kept only for compatibility in tests; actual prompt is sourced from OpenCode command files.
 pub const APPLY_SYSTEM_PROMPT: &str = "";
 
+/// Build an explicit, portable skill mention.
+///
+/// `load skills:` stays first for compatibility with Claude/OpenCode-style
+/// prompts; Codex activates local skills from the `$skill-name` mention.
+pub(crate) fn skill_prelude(skill: &str) -> String {
+    format!("load skills: {}\n\n${}", skill, skill)
+}
+
 /// Build apply prompt from change metadata, user prompt, history context, and acceptance tail
 /// Format: fixed prelude + user_prompt + APPLY_SYSTEM_PROMPT + acceptance_tail_context + history_context
 ///
@@ -43,7 +51,7 @@ pub fn build_apply_prompt_with_skill(
 ) -> String {
     let mut parts = Vec::new();
 
-    parts.push(format!("load skills: {}", apply_skill));
+    parts.push(skill_prelude(apply_skill));
     parts.push(format!("Apply change id: {}", change_id));
 
     if !user_prompt.is_empty() {
@@ -83,7 +91,7 @@ pub fn build_archive_prompt_with_skill(
 ) -> String {
     let mut parts = Vec::new();
 
-    parts.push(format!("load skills: {}", archive_skill));
+    parts.push(skill_prelude(archive_skill));
     parts.push(format!("Archive change id: {}", change_id));
 
     if !user_prompt.is_empty() {
@@ -117,7 +125,7 @@ pub fn build_cleanup_review_prompt_with_skill(
 ) -> String {
     let mut parts = Vec::new();
 
-    parts.push(format!("load skills: {}", cleanup_review_skill));
+    parts.push(skill_prelude(cleanup_review_skill));
     parts.push(format!("Cleanup-review change id: {}", change_id));
     parts.push(format!(
         "change_id: {}\nproposal_path: openspec/changes/{}/proposal.md\ntasks_path: openspec/changes/{}/tasks.md\nworkspace_path: .",
@@ -251,7 +259,7 @@ pub fn build_acceptance_prompt_context_only_with_skill(
 ) -> String {
     let mut parts = Vec::new();
 
-    parts.push(format!("load skills: {}", accept_skill));
+    parts.push(skill_prelude(accept_skill));
     parts.push(format!("Acceptance id:{}", change_id));
 
     // Change metadata first so downstream templates can reference it.
@@ -525,8 +533,9 @@ pub(crate) mod tests {
             "",
         );
 
+        assert!(result.contains("$cflx-accept-with-speca"));
         assert!(result.contains("load skills: cflx-accept-with-speca"));
-        assert!(!result.contains("load skills: cflx-accept\n"));
+        assert!(!result.contains("$cflx-accept\n"));
         assert!(result.contains("Acceptance id:test-change"));
     }
 
@@ -548,6 +557,7 @@ pub(crate) mod tests {
         );
 
         // Should contain prelude, change metadata and user prompt
+        assert!(result.contains("$cflx-accept"));
         assert!(result.contains("load skills: cflx-accept"));
         assert!(result.contains("Acceptance id:test-change"));
         assert!(result.contains("change_id: test-change"));
@@ -563,17 +573,20 @@ pub(crate) mod tests {
     fn test_operation_prompt_builders_use_custom_skill_preludes() {
         let apply =
             build_apply_prompt_with_skill("team-apply", "change-123", "user", "history", "");
+        assert!(apply.contains("$team-apply"));
         assert!(apply.contains("load skills: team-apply"));
-        assert!(!apply.contains("load skills: cflx-apply"));
+        assert!(!apply.contains("$cflx-apply"));
 
         let archive =
             build_archive_prompt_with_skill("team-archive", "change-123", "user", "history");
+        assert!(archive.contains("$team-archive"));
         assert!(archive.contains("load skills: team-archive"));
-        assert!(!archive.contains("load skills: cflx-archive"));
+        assert!(!archive.contains("$cflx-archive"));
 
         let cleanup = build_cleanup_review_prompt_with_skill("team-cleanup-review", "change-123");
+        assert!(cleanup.contains("$team-cleanup-review"));
         assert!(cleanup.contains("load skills: team-cleanup-review"));
-        assert!(!cleanup.contains("load skills: cflx-cleanup-review"));
+        assert!(!cleanup.contains("$cflx-cleanup-review"));
 
         let acceptance = build_acceptance_prompt_context_only_with_skill(
             "cflx-accept-with-speca",
@@ -583,8 +596,9 @@ pub(crate) mod tests {
             "last",
             "diff",
         );
+        assert!(acceptance.contains("$cflx-accept-with-speca"));
         assert!(acceptance.contains("load skills: cflx-accept-with-speca"));
-        assert!(!acceptance.contains("load skills: cflx-accept\n"));
+        assert!(!acceptance.contains("$cflx-accept\n"));
         assert!(acceptance.contains("change_id: change-123"));
     }
 
@@ -592,6 +606,7 @@ pub(crate) mod tests {
     fn test_build_cleanup_review_prompt_contains_required_context() {
         let prompt = build_cleanup_review_prompt("change-123");
 
+        assert!(prompt.contains("$cflx-cleanup-review"));
         assert!(prompt.contains("load skills: cflx-cleanup-review"));
         assert!(prompt.contains("Cleanup-review change id: change-123"));
         assert!(prompt.contains("change_id: change-123"));

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -1245,8 +1245,7 @@ impl AgentRunner {
         Ok((child, rx))
     }
 
-    /// Extract the result from stream-json output format
-    /// stream-json outputs multiple JSON lines, the last one with type="result" contains the actual result
+    /// Extract final assistant text from supported agent JSONL output formats.
     fn extract_stream_json_result(&self, output: &str) -> String {
         // Try to find and parse the result line from stream-json output
         for line in output.lines().rev() {
@@ -1271,6 +1270,16 @@ impl AgentRunner {
                                 if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
                                     return text.to_string();
                                 }
+                            }
+                        }
+                    }
+                }
+                // Codex `exec --json` emits the final assistant text as an item.completed event.
+                if json.get("type").and_then(|t| t.as_str()) == Some("item.completed") {
+                    if let Some(item) = json.get("item") {
+                        if item.get("type").and_then(|t| t.as_str()) == Some("agent_message") {
+                            if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                                return text.to_string();
                             }
                         }
                     }

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -204,6 +204,7 @@ fn test_build_apply_prompt_with_only_system_prompt() {
     let acceptance_tail = "";
     let result = build_apply_prompt("my-change", user_prompt, history_context, acceptance_tail);
 
+    assert!(result.contains("$cflx-apply"));
     assert!(result.contains("load skills: cflx-apply"));
     assert!(result.contains("Apply change id: my-change"));
     assert!(result.contains(APPLY_SYSTEM_PROMPT));
@@ -270,6 +271,7 @@ fn test_build_archive_prompt_with_all_parts() {
     let history_context = "<last_archive attempt=\"1\">\nstatus: failed\n</last_archive>";
     let result = build_archive_prompt("my-change", user_prompt, history_context);
 
+    assert!(result.contains("$cflx-archive"));
     assert!(result.contains("load skills: cflx-archive"));
     assert!(result.contains("Archive change id: my-change"));
     assert!(result.contains("Please archive this change"));
@@ -294,6 +296,7 @@ fn test_build_archive_prompt_with_empty_history() {
     let history_context = "";
     let result = build_archive_prompt("my-change", user_prompt, history_context);
 
+    assert!(result.contains("$cflx-archive"));
     assert!(result.contains("load skills: cflx-archive"));
     assert!(result.contains("Archive change id: my-change"));
     assert!(result.contains("Please archive this change"));
@@ -305,6 +308,7 @@ fn test_build_archive_prompt_both_empty() {
     let history_context = "";
     let result = build_archive_prompt("my-change", user_prompt, history_context);
 
+    assert!(result.contains("$cflx-archive"));
     assert!(result.contains("load skills: cflx-archive"));
     assert!(result.contains("Archive change id: my-change"));
 }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -348,6 +348,16 @@ impl ParallelizationAnalyzer {
                         }
                     }
                 }
+                // Codex `exec --json` emits the final assistant text as an item.completed event.
+                if json.get("type").and_then(|t| t.as_str()) == Some("item.completed") {
+                    if let Some(item) = json.get("item") {
+                        if item.get("type").and_then(|t| t.as_str()) == Some("agent_message") {
+                            if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                                return text.to_string();
+                            }
+                        }
+                    }
+                }
             }
         }
         // Fallback: return entire output if not stream-json format

--- a/src/orchestration/acceptance.rs
+++ b/src/orchestration/acceptance.rs
@@ -132,7 +132,7 @@ where
     let mut full_stdout = String::new();
 
     // Grace period after detecting an acceptance marker before terminating the process.
-    // This handles the case where the agent process (e.g., opencode) does not exit
+    // This handles the case where the agent process (or its child processes) does not exit
     // promptly after emitting ACCEPTANCE: PASS/FAIL/etc., for example because
     // child processes (MCP servers) keep stdout/stderr pipes open.
     const MARKER_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(30);
@@ -188,8 +188,8 @@ where
                 // period. This prevents indefinite blocking when the agent
                 // process does not exit after emitting the verdict. The
                 // detector recognises the primary strict JSON verdict (as a
-                // standalone line or wrapped in an opencode `--format json`
-                // event) and, as fallback, the legacy standalone plain-text
+                // standalone line or wrapped in a supported agent JSONL event)
+                // and, as fallback, the legacy standalone plain-text
                 // marker. Malformed markers with trailing text (for example
                 // "ACCEPTANCE: PASSAll ...") do NOT trigger early completion.
                 if !marker_detected && crate::acceptance::detect_verdict_in_line(&s).is_some() {

--- a/src/orchestration/rejection.rs
+++ b/src/orchestration/rejection.rs
@@ -41,8 +41,8 @@ fn rejection_review_prompt(change_id: &str) -> String {
 
 fn rejection_review_prompt_with_skill(rejecting_skill: &str, change_id: &str) -> String {
     format!(
-        "load skills: {}\n\nRejecting review id:{}\n\nchange_id: {}\nproposal_path: openspec/changes/{}/proposal.md\ntasks_path: openspec/changes/{}/tasks.md\nrejected_path: openspec/changes/{}/REJECTED.md",
-        rejecting_skill, change_id, change_id, change_id, change_id, change_id
+        "{}\n\nRejecting review id:{}\n\nchange_id: {}\nproposal_path: openspec/changes/{}/proposal.md\ntasks_path: openspec/changes/{}/tasks.md\nrejected_path: openspec/changes/{}/REJECTED.md",
+        crate::agent::prompt::skill_prelude(rejecting_skill), change_id, change_id, change_id, change_id, change_id
     )
 }
 
@@ -525,8 +525,9 @@ mod tests {
     #[test]
     fn test_rejection_review_prompt_uses_custom_skill_prelude() {
         let prompt = rejection_review_prompt_with_skill("team-rejecting", "change-a");
+        assert!(prompt.contains("$team-rejecting"));
         assert!(prompt.contains("load skills: team-rejecting"));
-        assert!(!prompt.contains("load skills: cflx-rejecting"));
+        assert!(!prompt.contains("$cflx-rejecting"));
         assert!(prompt.contains("Rejecting review id:change-a"));
     }
 

--- a/src/orchestration/selection.rs
+++ b/src/orchestration/selection.rs
@@ -128,10 +128,11 @@ fn build_analysis_prompt_with_skill(analyze_skill: &str, changes: &[Change]) -> 
         .join("\n");
 
     format!(
-        "load skills: {}\n\n\
+        "{}\n\n\
          Queued changes:\n\
          {}\n",
-        analyze_skill, change_list
+        crate::agent::prompt::skill_prelude(analyze_skill),
+        change_list
     )
 }
 
@@ -205,6 +206,7 @@ mod tests {
         let prompt = build_analysis_prompt(&changes);
 
         // Verify skill prelude
+        assert!(prompt.contains("$cflx-analyze"));
         assert!(prompt.contains("load skills: cflx-analyze"));
 
         // Verify prompt contains variable context (change IDs and progress)
@@ -224,8 +226,9 @@ mod tests {
         let changes = vec![test_change("add-feature", 2, 5)];
         let prompt = build_analysis_prompt_with_skill("team-analyze", &changes);
 
+        assert!(prompt.contains("$team-analyze"));
         assert!(prompt.contains("load skills: team-analyze"));
-        assert!(!prompt.contains("load skills: cflx-analyze"));
+        assert!(!prompt.contains("$cflx-analyze"));
         assert!(prompt.contains("add-feature"));
     }
 
@@ -235,6 +238,7 @@ mod tests {
         let prompt = build_analysis_prompt(&changes);
 
         // Prompt should still have skill prelude and structure
+        assert!(prompt.contains("$cflx-analyze"));
         assert!(prompt.contains("load skills: cflx-analyze"));
         assert!(prompt.contains("Queued changes:"));
     }

--- a/src/parallel/conflict.rs
+++ b/src/parallel/conflict.rs
@@ -1025,7 +1025,7 @@ fn build_conflict_resolve_prompt(
     conflict_files_str: &str,
 ) -> String {
     format!(
-        "load skills: {}\n\n\
+        "{}\n\n\
          {}\n\n\
          Conflicting revisions: {}\n\n\
          VCS error output:\n\
@@ -1035,7 +1035,7 @@ fn build_conflict_resolve_prompt(
          VCS log for conflicting changes:\n\
          {}\n\n\
          Conflicting files: {}",
-        resolve_skill,
+        crate::agent::prompt::skill_prelude(resolve_skill),
         vcs_prompt_prefix,
         revisions.join(", "),
         vcs_error,
@@ -1059,7 +1059,7 @@ fn build_sequential_merge_resolve_prompt(
     conflict_files_str: &str,
 ) -> String {
     format!(
-        "load skills: {}\n\n\
+        "{}\n\n\
          {}\n\n\
          Operation: sequential merge\n\n\
          Target branch: {}\n\
@@ -1069,7 +1069,7 @@ fn build_sequential_merge_resolve_prompt(
          Current VCS status:\n{}\n\n\
          VCS log for branches:\n{}\n\n\
          Conflicting files (repo root, if any): {}",
-        resolve_skill,
+        crate::agent::prompt::skill_prelude(resolve_skill),
         vcs_prompt_prefix,
         target_branch,
         base_revision,
@@ -1096,6 +1096,7 @@ mod tests {
             "commit log here",
             "file.rs",
         );
+        assert!(prompt.contains("$cflx-resolve"));
         assert!(prompt.contains("load skills: cflx-resolve"));
         // Variable context present
         assert!(prompt.contains("branch-a, branch-b"));
@@ -1113,8 +1114,9 @@ mod tests {
             "log",
             "files",
         );
+        assert!(prompt.contains("$team-resolve"));
         assert!(prompt.contains("load skills: team-resolve"));
-        assert!(!prompt.contains("load skills: cflx-resolve"));
+        assert!(!prompt.contains("$cflx-resolve"));
     }
 
     #[test]
@@ -1156,6 +1158,7 @@ mod tests {
             "log entries",
             "(none)",
         );
+        assert!(prompt.contains("$cflx-resolve"));
         assert!(prompt.contains("load skills: cflx-resolve"));
         assert!(prompt.contains("Operation: sequential merge"));
         // Variable context present
@@ -1177,8 +1180,9 @@ mod tests {
             "log",
             "files",
         );
+        assert!(prompt.contains("$team-resolve"));
         assert!(prompt.contains("load skills: team-resolve"));
-        assert!(!prompt.contains("load skills: cflx-resolve"));
+        assert!(!prompt.contains("$cflx-resolve"));
     }
 
     #[test]

--- a/src/parallel/executor.rs
+++ b/src/parallel/executor.rs
@@ -1296,7 +1296,7 @@ pub async fn execute_acceptance_in_workspace(
 
     // Grace period after detecting a canonical standalone verdict before
     // terminating the acceptance child process. This handles the case where
-    // the agent process (e.g. opencode + MCP child processes) does not exit
+    // the agent process (or its child processes) does not exit
     // promptly after emitting the verdict but keeps stdout/stderr pipes open,
     // which previously left acceptance to wait for inactivity timeout retry.
     let verdict_grace_period = acceptance_verdict_grace_period();
@@ -1357,7 +1357,7 @@ pub async fn execute_acceptance_in_workspace(
 
                 // Detect canonical verdict and start grace period.
                 // Primary: strict JSON verdict object (standalone or wrapped in
-                // an opencode `--format json` event). Fallback: strict plain-text
+                // a supported agent JSONL event). Fallback: strict plain-text
                 // standalone canonical marker. Trailing-text concatenation on
                 // the plain-text marker does NOT count.
                 if !verdict_detected && crate::acceptance::detect_verdict_in_line(&s).is_some() {

--- a/src/stream_json_textifier.rs
+++ b/src/stream_json_textifier.rs
@@ -1,6 +1,6 @@
-//! Stream-JSON output textification for Claude Code `--output-format stream-json`.
+//! Stream-JSON output textification for AI agent JSONL output.
 //!
-//! Converts NDJSON event lines emitted by Claude Code into human-readable text
+//! Converts NDJSON event lines emitted by AI agents into human-readable text
 //! with line-oriented buffering.  Each JSON event that carries text is decoded;
 //! tool-related events are converted to one-line summaries;
 //! other non-text events (system init messages, thinking, …) are suppressed
@@ -35,6 +35,7 @@ pub fn is_stream_json_event(line: &str) -> bool {
 /// - `stream_event` with `event.delta.type = "text_delta"`: streaming text chunk
 /// - `assistant` with `message.content[].type = "text"`: full assistant text block
 /// - `result` with a non-empty, non-error `result` field: final result text
+/// - `item.completed` with `item.type = "agent_message"`: Codex final assistant text
 pub fn extract_text_from_stream_json(line: &str) -> Option<String> {
     let trimmed = line.trim();
     if !trimmed.starts_with('{') {
@@ -47,6 +48,7 @@ pub fn extract_text_from_stream_json(line: &str) -> Option<String> {
         "stream_event" => extract_from_stream_event(&value),
         "assistant" => extract_from_assistant(&value),
         "result" => extract_from_result(&value),
+        "item.completed" => extract_from_codex_item_completed(&value),
         _ => None,
     }
 }
@@ -102,6 +104,20 @@ fn extract_from_result(value: &serde_json::Value) -> Option<String> {
     }
 }
 
+fn extract_from_codex_item_completed(value: &serde_json::Value) -> Option<String> {
+    // {"type":"item.completed","item":{"type":"agent_message","text":"..."}}
+    let item = value.get("item")?;
+    if item.get("type")?.as_str()? != "agent_message" {
+        return None;
+    }
+    let text = item.get("text")?.as_str()?;
+    if text.is_empty() {
+        None
+    } else {
+        Some(text.to_string())
+    }
+}
+
 /// Extract a one-line summary from tool-related stream-json events.
 ///
 /// Returns `Some(summary)` for `tool_use` and `tool_result` events.
@@ -119,11 +135,43 @@ pub fn extract_tool_summary_from_stream_json(line: &str) -> Option<String> {
     let event_type = value.get("type")?.as_str()?;
 
     match event_type {
+        "item.completed" => extract_codex_item_summary(&value),
         "tool_use" => extract_tool_use_summary(&value),
         "tool_result" => extract_tool_result_summary(&value),
         "assistant" => extract_assistant_tool_summary(&value),
         _ => None,
     }
+}
+
+fn extract_codex_item_summary(value: &serde_json::Value) -> Option<String> {
+    let item = value.get("item")?;
+    let item_type = item.get("type")?.as_str()?;
+    match item_type {
+        "file_change" => extract_codex_file_change_summary(item),
+        _ => None,
+    }
+}
+
+fn extract_codex_file_change_summary(item: &serde_json::Value) -> Option<String> {
+    let changes = item.get("changes")?.as_array()?;
+    if changes.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    for change in changes.iter().take(5) {
+        let path = change.get("path").and_then(|v| v.as_str()).unwrap_or("?");
+        let kind = change
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or("change");
+        parts.push(format!("{}:{}", kind, path));
+    }
+    if changes.len() > 5 {
+        parts.push(format!("+{} more", changes.len() - 5));
+    }
+
+    Some(format!("[file_change] {}", parts.join(", ")))
 }
 
 fn extract_tool_use_summary(value: &serde_json::Value) -> Option<String> {
@@ -473,6 +521,21 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_codex_item_completed_agent_message() {
+        let line = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Hello from Codex"}}"#;
+        assert_eq!(
+            extract_text_from_stream_json(line),
+            Some("Hello from Codex".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_codex_item_completed_non_message_suppressed() {
+        let line = r#"{"type":"item.completed","item":{"id":"item_0","type":"tool_call","text":"ignore"}}"#;
+        assert_eq!(extract_text_from_stream_json(line), None);
+    }
+
+    #[test]
     fn test_non_json_returns_none() {
         assert_eq!(extract_text_from_stream_json("plain text"), None);
         assert_eq!(extract_text_from_stream_json(""), None);
@@ -567,6 +630,26 @@ mod tests {
         let line = r#"{"type":"system","subtype":"init"}"#;
         let result = process_stdout_line(line, &mut buf);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_process_codex_item_completed_buffers_text() {
+        let mut buf = StreamJsonTextBuffer::new();
+        let line = r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"line1\nline2"}}"#;
+        let result = process_stdout_line(line, &mut buf);
+        assert_eq!(result, vec!["line1".to_string()]);
+        assert_eq!(buf.finalize(), Some("line2".to_string()));
+    }
+
+    #[test]
+    fn test_process_codex_file_change_summary() {
+        let mut buf = StreamJsonTextBuffer::new();
+        let line = r#"{"type":"item.completed","item":{"id":"item_1","type":"file_change","changes":[{"path":"src/main.rs","kind":"modify"},{"path":"README.md","kind":"add"}],"status":"completed"}}"#;
+        let result = process_stdout_line(line, &mut buf);
+        assert_eq!(
+            result,
+            vec!["[file_change] modify:src/main.rs, add:README.md".to_string()]
+        );
     }
 
     #[test]

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -186,23 +186,23 @@ pub const CODEX_TEMPLATE: &str = r#"{
   // Template: Codex
 
   // Command to analyze dependencies and select next change
-  "analyze_command": "codex --json {prompt}",
+  "analyze_command": "codex -a never exec --json --sandbox workspace-write '{prompt}'",
 
   // Command to apply a change (supports {change_id} and {prompt} placeholders)
-  "apply_command": "codex '{prompt}'",
+  "apply_command": "codex -a never exec --sandbox workspace-write '{prompt}'",
 
   // Command to archive a completed change (supports {change_id} and {prompt} placeholders)
-  "archive_command": "codex '{prompt}'",
+  "archive_command": "codex -a never exec --sandbox workspace-write '{prompt}'",
 
   // Command to run acceptance tests after apply (supports {change_id} and {prompt} placeholders)
-  "acceptance_command": "codex '{prompt}'",
+  "acceptance_command": "codex -a never exec --sandbox workspace-write '{prompt}'",
 
   // Operation skill for acceptance prompts (defaults to cflx-accept).
   // Opt into SPECA-style property review without changing acceptance_command:
   // "accept_skill": "cflx-accept-with-speca",
 
   // Command to resolve conflicts (supports {prompt} placeholder)
-  "resolve_command": "codex {prompt}",
+  "resolve_command": "codex -a never exec --sandbox workspace-write '{prompt}'",
 
   // Operation skill preludes loaded into generated prompts (all optional; shown with defaults)
   // Example: set accept_skill to "cflx-accept-with-speca" to customize acceptance guidance only.
@@ -359,9 +359,18 @@ mod tests {
 
     #[test]
     fn test_codex_template_matches_sample_style() {
-        assert!(CODEX_TEMPLATE.contains("\"apply_command\": \"codex '{prompt}'\""));
-        assert!(CODEX_TEMPLATE.contains("\"archive_command\": \"codex '{prompt}'\""));
-        assert!(CODEX_TEMPLATE.contains("\"acceptance_command\": \"codex '{prompt}'\""));
+        assert!(CODEX_TEMPLATE.contains(
+            "\"analyze_command\": \"codex -a never exec --json --sandbox workspace-write '{prompt}'\""
+        ));
+        assert!(CODEX_TEMPLATE.contains(
+            "\"apply_command\": \"codex -a never exec --sandbox workspace-write '{prompt}'\""
+        ));
+        assert!(CODEX_TEMPLATE.contains(
+            "\"archive_command\": \"codex -a never exec --sandbox workspace-write '{prompt}'\""
+        ));
+        assert!(CODEX_TEMPLATE.contains(
+            "\"acceptance_command\": \"codex -a never exec --sandbox workspace-write '{prompt}'\""
+        ));
         assert!(CODEX_TEMPLATE.contains("\"worktree_command\": \"tmux new-window -n wt \""));
         assert!(!CODEX_TEMPLATE.contains("\"acceptance_prompt_mode\""));
         assert!(CODEX_TEMPLATE.contains("\"accept_skill\": \"cflx-accept-with-speca\""));


### PR DESCRIPTION
## Summary

- Update the Codex init template to use `codex -a never exec` with workspace-write sandboxing for orchestration commands.
- Add Codex JSONL support for `item.completed` assistant messages and file-change summaries across textification, analysis, runner extraction, and acceptance verdict parsing.
- Emit a portable skill prelude that keeps `load skills: ...` for Claude/OpenCode compatibility while adding `$skill-name` for Codex native skill activation.

Closes #10

## Issue

Conflux's Codex template and parsers assumed command shapes/output formats that do not match current Codex CLI behavior:

- `codex --json <prompt>` is rejected by Codex CLI; non-interactive usage requires `codex exec`.
- `codex exec` defaults to read-only, so write-capable operations need `--sandbox workspace-write`.
- Codex JSON mode emits JSONL events like `item.completed`, which were not extracted by the existing Claude/OpenCode stream-json handling.
- Codex native skills require `$skill-name` mention, while existing prompts only used `load skills: ...`.

## Solution

This PR makes Codex a first-class runtime without removing Claude/OpenCode compatibility:

- Generated Codex config now uses `codex -a never exec ...`.
- Analyzer/runner/textifier/acceptance parser can extract final assistant text from Codex `item.completed` events.
- Acceptance JSON verdicts can be parsed from Codex JSONL output.
- Prompts now include both forms:

```text
load skills: cflx-apply

$cflx-apply
```

## Verification

- `cargo fmt`
- `cargo check`
- `cargo test agent::tests`
- `cargo test prompt::tests`
- `cargo test codex_template`
- `cargo test stream_json_textifier`
- `cargo test acceptance::`
- `cargo test orchestration::selection`
- `cargo test parallel::conflict`
- Codex smoke test confirmed combined `load skills: cflx-apply` + `$cflx-apply` activates the skill.

Note: `cargo test orchestration::rejection` has an unrelated local hook/user-name failure in this environment.